### PR TITLE
Update manager.inc to allow mount of labeled filesystems

### DIFF
--- a/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/manager.inc
+++ b/deb/openmediavault/usr/share/php/openmediavault/system/filesystem/backend/manager.inc
@@ -130,18 +130,26 @@ class Manager implements \IteratorAggregate {
 		$enums = $this->enumerate();
 		foreach ($enums as $enumk => $enumv) {
 			$found = FALSE;
-			if (is_devicefile($id)) {
+			if ( is_fs_uuid($id)) {
+				// Compare the filesystem UUID.
+				$found = ($id == $enumv['uuid']);
+			}
+			if ( !$found && is_devicefile_by($id)) {
+				// The label consists of all not-slashes at the end of
+				// label device path
+				$regex = '/[^\/]+$/';
+				unset($matches);
+				if ( 1 == preg_match($regex, $id, $matches) ){
+					$found = ($matches[0] == $enumv['label']);
+				}
+			}
+			if ( !$found && is_devicefile($id)) {
 				// Compare the device file name. Use the canonical device
 				// files for an additional check.
 				if ($id == $enumv['devicefile'])
 					$found = TRUE;
 				else if (realpath($id) == realpath($enumv['devicefile']))
 					$found = TRUE;
-			} else if (is_fs_uuid($id)) {
-				// Compare the filesystem UUID.
-				$found = ($id == $enumv['uuid']);
-			} else {
-				$found = ($id == $enumv['label']);
 			}
 			if (TRUE === $found) {
 				$result = $this->getBackendByType($enumv['type']);


### PR DESCRIPTION
1) Reordered checks by specicifity
is_devicefile will catch anything in /dev and its subdirectories, so I think it should be done last. (Sidenote: Maybe you wanted ^\/dev\/[^\/]+$ in functions.inc?)
2) Label will never match the full /dev/disk/by-label path, so I propose to match only the string after the last slash. (This might be beneficial for the uuid part, too, but I didn't make this change here.)
3) The final else statement only handled the "label" case (and didn't in case the label wasn't on its own ;-) making it unnecessary. The proposed change should handle isolated labels as well as labels with path, because labels can't contain slashes afaik.
4) I didn't use else-if constructs, because the label case has a sub condition with a regex match and I didn't know how to do that as an && in the first condition. To keep things consistent used !found in all conditions except obviously the first.

I've never coded in PHP before, so please forgive me if it looks clumsy.


<!--
Thank you for opening a pull request! Here are some tips on creating a well formatted contribution.

Please give your pull request a title like "[Short description]"

This is the format for commit messages:

"""
[Short description]

[A longer multiline description]

Fixes: [ISSUE_URL or #ISSUE_ID, create one if necessary]

Signed-off-by: [YOUR_NAME] <[YOUR_EMAIL]>
"""

The Signed-off-by line is important, and it is your certification that your contributions satisfy the developers certificate or origin.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview. More information for contributors is available here:
https://docs.openmediavault.org/en/latest/development/contribute.html
-->

- [ ] References issue
- [ ] Includes tests for new functionality or reproducer for bug
